### PR TITLE
fix min colorama version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
   url="https://github.com/idchlife/clrc",
   packages=setuptools.find_packages(),
   install_requires=[
-    "colorama==0.4.1"
+    "colorama==0.4.5"
   ],
   classifiers=[
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Latest version is incompatible with latest pylint

The conflict is caused by:
    clrc 0.0.5 depends on colorama==0.4.1
    pylint 2.16.2 depends on colorama>=0.4.5; (sys_platform == "win32")

Just cnange version to resolve this